### PR TITLE
Rebrand from Webfox to Foxbyte

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) webfox <developers@webfox.co.nz>
+Copyright (c) Foxbyte Ltd <devops@foxbyte.nz>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Data Providers for Inertia.js
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/webfox/laravel-inertia-dataproviders.svg?style=flat-square)](https://packagist.org/packages/webfox/laravel-inertia-dataproviders)
-[![Total Downloads](https://img.shields.io/packagist/dt/webfox/laravel-inertia-dataproviders.svg?style=flat-square)](https://packagist.org/packages/webfox/laravel-inertia-dataproviders)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/foxbytehq/laravel-inertia-dataproviders.svg?style=flat-square)](https://packagist.org/packages/foxbytehq/laravel-inertia-dataproviders)
+[![Total Downloads](https://img.shields.io/packagist/dt/foxbytehq/laravel-inertia-dataproviders.svg?style=flat-square)](https://packagist.org/packages/foxbytehq/laravel-inertia-dataproviders)
 
 Data providers encapsulate logic for Inertia views, keep your controllers clean and simple.
 
@@ -10,13 +10,13 @@ Data providers encapsulate logic for Inertia views, keep your controllers clean 
 Install this package via composer:
 
 ```bash
-composer require webfox/laravel-inertia-dataproviders
+composer require foxbytehq/laravel-inertia-dataproviders
 ```
 
 Optionally publish the configuration file:
 
 ```bash
-php artisan vendor:publish --provider="Webfox\InertiaDataProviders\InertiaDataProvidersServiceProvider"
+php artisan vendor:publish --provider="Foxbyte\InertiaDataProviders\InertiaDataProvidersServiceProvider"
 ````
 
 We assume you've already got the Inertia adapter for Laravel installed.
@@ -99,7 +99,7 @@ namespace App\Http\DataProviders;
 
 use Inertia\LazyProp;
 use App\Services\InjectedDependency;
-use Webfox\InertiaDataProviders\DataProvider;
+use Foxbyte\InertiaDataProviders\DataProvider;
 
 class DemoDataProvider extends DataProvider
 {
@@ -123,7 +123,7 @@ namespace App\Http\DataProviders;
 use Inertia\DeferProp;
 use Inertia\LazyProp;
 use App\Services\InjectedDependency;
-use Webfox\InertiaDataProviders\DataProvider;
+use Foxbyte\InertiaDataProviders\DataProvider;
 
 class DemoDataProvider extends DataProvider
 {
@@ -303,7 +303,7 @@ class DemoController extends Controller
 
 ## Attribute Name Formatting
 The attribute name format can be configured in the configuration file by setting the `attribute_name_formatter`.  
-The package ships with three formatters under the namespace `\Webfox\InertiaDataProviders\AttributeNameFormatters` but you are free to create your own.
+The package ships with three formatters under the namespace `\Foxbyte\InertiaDataProviders\AttributeNameFormatters` but you are free to create your own.
 
 ### AsWritten
 This is the default formatter. The output attribute name will be the same as the input name.

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,23 @@
 {
-    "name": "webfox/laravel-inertia-dataproviders",
+    "name": "foxbytehq/laravel-inertia-dataproviders",
     "description": "Data providers to encapsulate logic for Inertia views",
     "keywords": [
-        "webfox",
+        "foxbytehq",
         "laravel",
         "inertia"
     ],
-    "homepage": "https://github.com/webfox/laravel-inertia-dataproviders",
+    "homepage": "https://github.com/foxbytehq/laravel-inertia-dataproviders",
     "license": "MIT",
     "authors": [
         {
-            "name": "Webfox Developments Ltd",
-            "email": "developers@webfox.co.nz",
+            "name": "Foxbyte Ltd",
+            "email": "devops@foxbyte.nz",
             "role": "Developer"
         }
     ],
+    "replace": {
+        "webfox/laravel-inertia-dataproviders": "*"
+    },
     "suggest": {
         "inertiajs/inertia-laravel": "Needed for basic inertia functionality"
     },
@@ -38,12 +41,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Webfox\\InertiaDataProviders\\": "src"
+            "Foxbyte\\InertiaDataProviders\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Webfox\\InertiaDataProviders\\Tests\\": "tests"
+            "Foxbyte\\InertiaDataProviders\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -61,7 +64,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Webfox\\InertiaDataProviders\\InertiaDataProvidersServiceProvider"
+                "Foxbyte\\InertiaDataProviders\\InertiaDataProvidersServiceProvider"
             ]
         }
     },

--- a/config/inertia-dataproviders.php
+++ b/config/inertia-dataproviders.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'attribute_name_formatter' => \Webfox\InertiaDataProviders\AttributeNameFormatters\AsWritten::class,
+    'attribute_name_formatter' => \Foxbyte\InertiaDataProviders\AttributeNameFormatters\AsWritten::class,
 ];

--- a/ide.json
+++ b/ide.json
@@ -2,7 +2,7 @@
   "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
   "codeGenerations": [
     {
-      "id": "webfox.create-inertia-data-provider",
+      "id": "foxbyte.create-inertia-data-provider",
       "name": "Create Inertia Data Provider",
       "classSuffix": "DataProvider",
       "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
     verbose="true"
 >
     <testsuites>
-        <testsuite name="Webfox Test Suite">
+        <testsuite name="Foxbyte Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/AttributeNameFormatters/AsWritten.php
+++ b/src/AttributeNameFormatters/AsWritten.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders\AttributeNameFormatters;
+namespace Foxbyte\InertiaDataProviders\AttributeNameFormatters;
 
 class AsWritten implements AttributeNameFormatter
 {

--- a/src/AttributeNameFormatters/AttributeNameFormatter.php
+++ b/src/AttributeNameFormatters/AttributeNameFormatter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders\AttributeNameFormatters;
+namespace Foxbyte\InertiaDataProviders\AttributeNameFormatters;
 
 interface AttributeNameFormatter
 {

--- a/src/AttributeNameFormatters/CamelCase.php
+++ b/src/AttributeNameFormatters/CamelCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders\AttributeNameFormatters;
+namespace Foxbyte\InertiaDataProviders\AttributeNameFormatters;
 
 use Illuminate\Support\Str;
 

--- a/src/AttributeNameFormatters/SnakeCase.php
+++ b/src/AttributeNameFormatters/SnakeCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders\AttributeNameFormatters;
+namespace Foxbyte\InertiaDataProviders\AttributeNameFormatters;
 
 use Illuminate\Support\Str;
 

--- a/src/DataProvider.php
+++ b/src/DataProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Foxbyte\InertiaDataProviders;
 
 use Closure;
+use Foxbyte\InertiaDataProviders\AttributeNameFormatters\AttributeNameFormatter;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Inertia\DeferProp;
@@ -15,7 +16,6 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionProperty;
 use Symfony\Component\VarDumper\VarDumper;
-use Foxbyte\InertiaDataProviders\AttributeNameFormatters\AttributeNameFormatter;
 
 abstract class DataProvider implements Arrayable, Jsonable
 {

--- a/src/DataProvider.php
+++ b/src/DataProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Webfox\InertiaDataProviders;
+namespace Foxbyte\InertiaDataProviders;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
@@ -15,7 +15,7 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionProperty;
 use Symfony\Component\VarDumper\VarDumper;
-use Webfox\InertiaDataProviders\AttributeNameFormatters\AttributeNameFormatter;
+use Foxbyte\InertiaDataProviders\AttributeNameFormatters\AttributeNameFormatter;
 
 abstract class DataProvider implements Arrayable, Jsonable
 {

--- a/src/DataProviderCollection.php
+++ b/src/DataProviderCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Webfox\InertiaDataProviders;
+namespace Foxbyte\InertiaDataProviders;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;

--- a/src/InertiaDataProviderMakeCommand.php
+++ b/src/InertiaDataProviderMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders;
+namespace Foxbyte\InertiaDataProviders;
 
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/InertiaDataProvidersServiceProvider.php
+++ b/src/InertiaDataProvidersServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webfox\InertiaDataProviders;
+namespace Foxbyte\InertiaDataProviders;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;

--- a/stubs/inertia-data-provider.stub
+++ b/stubs/inertia-data-provider.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use Webfox\InertiaDataProviders\DataProvider;
+use Foxbyte\InertiaDataProviders\DataProvider;
 
 class {{ class }} extends DataProvider
 {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,5 @@
 <?php
 
-use Webfox\InertiaDataProviders\Tests\TestCase;
+use Foxbyte\InertiaDataProviders\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace Foxbyte\InertiaDataProviders\Tests;
 
+use Foxbyte\InertiaDataProviders\InertiaDataProvidersServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Foxbyte\InertiaDataProviders\InertiaDataProvidersServiceProvider;
 
 class TestCase extends Orchestra
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Webfox\InertiaDataProviders\Tests;
+namespace Foxbyte\InertiaDataProviders\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Webfox\InertiaDataProviders\InertiaDataProvidersServiceProvider;
+use Foxbyte\InertiaDataProviders\InertiaDataProvidersServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Webfox\\InertiaDataProviders\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName) => 'Foxbyte\\InertiaDataProviders\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
     }
 


### PR DESCRIPTION
## Summary
  Complete rebranding of the package from Webfox to Foxbyte, preparing for republication under the new company name.

  ## Changes Made
  - **Company Identity**
    - Updated company name from "Webfox Developments Ltd" to "Foxbyte Ltd"
    - Changed contact email from `developers@webfox.co.nz` to `devops@foxbyte.nz`

  - **Package Identity**
    - Changed package name from `webfox/laravel-inertia-dataproviders` to `foxbytehq/laravel-inertia-dataproviders`
    - Updated all namespace declarations from `Webfox\InertiaDataProviders` to `Foxbyte\InertiaDataProviders`
    - Added `replace` field in composer.json to indicate this package replaces the old one

  - **Repository & Documentation**
    - Updated GitHub URLs to reflect new organization (`foxbytehq`)
    - Updated Packagist badges and installation instructions in README
    - Updated test suite name and IDE configuration
    - Updated all code examples and documentation references

  ## Migration Path
  This change prepares the package for:
  1. Abandoning the old `webfox/laravel-inertia-dataproviders` package on Packagist
  2. Publishing the new `foxbytehq/laravel-inertia-dataproviders` package

  Users can migrate by:
  1. Updating their `composer.json` to use the new package name
  2. Running `composer update`
  3. Updating namespace imports in their code from `Webfox\InertiaDataProviders` to `Foxbyte\InertiaDataProviders`
